### PR TITLE
fix translation not picking up strings + German translation

### DIFF
--- a/ubports-seabass/po/de.po
+++ b/ubports-seabass/po/de.po
@@ -1,0 +1,68 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the seabass2.mikhael package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: seabass2.mikhael\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-05-25 20:21+0000\n"
+"PO-Revision-Date: 2020-05-25 22:24+0200\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3.1\n"
+"Last-Translator: Daniel Frost <one@frostinfo.de>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: de\n"
+
+#: ../qml/Main.qml:26
+msgid "Welcome"
+msgstr "Willkommen"
+
+#: ../qml/Main.qml:141 ../qml/components/FileList.qml:22
+msgid "Files"
+msgstr "Dateien"
+
+#: ../qml/Main.qml:149 ../qml/components/SaveDialog.qml:26
+msgid "Save"
+msgstr "Speichern"
+
+#: ../qml/components/ErrorDialog.qml:7
+msgid "unknown error"
+msgstr "unbekannter Fehler"
+
+#: ../qml/components/ErrorDialog.qml:19
+msgid "Error occured"
+msgstr "Fehler entdeckt"
+
+#: ../qml/components/ErrorDialog.qml:22 ../qml/components/FileList.qml:28
+#: ../qml/components/FileList.qml:37 ../qml/components/SaveDialog.qml:34
+msgid "Close"
+msgstr "Schließen"
+
+#: ../qml/components/SaveDialog.qml:23
+msgid "Save changes in %1?"
+msgstr "Änderungen speichern in %1?"
+
+#: ../qml/components/SaveDialog.qml:24
+msgid "Changes will be lost if you close the file without saving."
+msgstr "Änderungen gehen verloren wenn die Datei ohne speichern geschlossen wird."
+
+#: ../qml/components/SaveDialog.qml:42
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: ../qml/generic/EditorApi.qml:55
+msgid "Unable to read file. Please ensure that you have read access to the"
+msgstr "Datei kann nicht gelesen werden. Bitte stelle sicher, dass Lesezugriff besteht für"
+
+#: ../qml/generic/EditorApi.qml:89
+msgid "Unable to write the file. Please ensure that you have write access to"
+msgstr "Datei kann nicht geschrieben werden. Bitte stelle sicher, dass Schreibzugriff besteht für"
+
+#: seabass2.desktop.in.h:1
+msgid "Seabass2"
+msgstr "Seabass2"

--- a/ubports-seabass/po/seabass2.mikhael.pot
+++ b/ubports-seabass/po/seabass2.mikhael.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: seabass2.mikhael\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-25 06:32+0000\n"
+"POT-Creation-Date: 2020-05-25 20:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,51 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#: ../qml/Main.qml:26
+msgid "Welcome"
+msgstr ""
+
+#: ../qml/Main.qml:141 ../qml/components/FileList.qml:22
+msgid "Files"
+msgstr ""
+
+#: ../qml/Main.qml:149 ../qml/components/SaveDialog.qml:26
+msgid "Save"
+msgstr ""
+
+#: ../qml/components/ErrorDialog.qml:7
+msgid "unknown error"
+msgstr ""
+
+#: ../qml/components/ErrorDialog.qml:19
+msgid "Error occured"
+msgstr ""
+
+#: ../qml/components/ErrorDialog.qml:22 ../qml/components/FileList.qml:28
+#: ../qml/components/FileList.qml:37 ../qml/components/SaveDialog.qml:34
+msgid "Close"
+msgstr ""
+
+#: ../qml/components/SaveDialog.qml:23
+msgid "Save changes in %1?"
+msgstr ""
+
+#: ../qml/components/SaveDialog.qml:24
+msgid "Changes will be lost if you close the file without saving."
+msgstr ""
+
+#: ../qml/components/SaveDialog.qml:42
+msgid "Cancel"
+msgstr ""
+
+#: ../qml/generic/EditorApi.qml:55
+msgid "Unable to read file. Please ensure that you have read access to the"
+msgstr ""
+
+#: ../qml/generic/EditorApi.qml:89
+msgid "Unable to write the file. Please ensure that you have write access to"
+msgstr ""
 
 #: seabass2.desktop.in.h:1
 msgid "Seabass2"

--- a/ubports-seabass/qml/Main.qml
+++ b/ubports-seabass/qml/Main.qml
@@ -23,7 +23,7 @@ MainView {
   height: units.gu(60)
 
   readonly property bool isWide: width >= units.gu(100)
-  readonly property string defaultTitle: qsTr("Welcome")
+  readonly property string defaultTitle: i18n.tr("Welcome")
   readonly property string defaultSubTitle: "Seabass"
 
   GenericComponents.FilesModel {
@@ -138,7 +138,7 @@ MainView {
             Action {
               visible: !isWide || !navBar.visible
               iconName: "navigation-menu"
-              text: qsTr("Files")
+              text: i18n.tr("Files")
               onTriggered: navBar.visible = !navBar.visible
             }
           ]
@@ -146,7 +146,7 @@ MainView {
             actions: [
               Action {
                 iconName: "save"
-                text: qsTr("Save")
+                text: i18n.tr("Save")
                 enabled: api.filePath && api.hasChanges
                 shortcut: StandardKey.Save
                 onTriggered: {

--- a/ubports-seabass/qml/components/ErrorDialog.qml
+++ b/ubports-seabass/qml/components/ErrorDialog.qml
@@ -4,7 +4,7 @@ import Ubuntu.Components.Popups 1.3
 import "../generic/utils.js" as QmlJs
 
 Item {
-  property string message: qsTr('unknown error')
+  property string message: i18n.tr('unknown error')
 
   function show(errorMsg) {
     message = errorMsg
@@ -16,10 +16,10 @@ Item {
 
     Dialog {
       id: dialogue
-      title: qsTr('Error occured')
+      title: i18n.tr('Error occured')
       text: message
       Button {
-        text: qsTr("Close")
+        text: i18n.tr("Close")
         onClicked: {
           PopupUtils.close(dialogue)
         }

--- a/ubports-seabass/qml/components/FileList.qml
+++ b/ubports-seabass/qml/components/FileList.qml
@@ -19,13 +19,13 @@ ListView {
   signal fileSelected(string filePath)
 
   header: PageHeader {
-    title: qsTr("Files")
+    title: i18n.tr("Files")
     subtitle: folderModel.folder.toString().replace('file://', '')
     navigationActions:[
       Action {
         visible: isPage
         iconName: "back"
-        text: qsTr("Close")
+        text: i18n.tr("Close")
         onTriggered: closed()
       }
     ]
@@ -34,7 +34,7 @@ ListView {
         Action {
           visible: !isPage
           iconName: "close"
-          text: qsTr("Close")
+          text: i18n.tr("Close")
           onTriggered: closed()
         }
       ]

--- a/ubports-seabass/qml/components/SaveDialog.qml
+++ b/ubports-seabass/qml/components/SaveDialog.qml
@@ -20,10 +20,10 @@ Item {
 
     Dialog {
       id: dialogue
-      title: qsTr("Save changes in %1?").arg(fileName)
-      text: qsTr("Changes will be lost if you close the file without saving.")
+      title: i18n.tr("Save changes in %1?").arg(fileName)
+      text: i18n.tr("Changes will be lost if you close the file without saving.")
       Button {
-        text: qsTr("Save")
+        text: i18n.tr("Save")
         color: theme.palette.normal.positive
         onClicked: {
           PopupUtils.close(dialogue)
@@ -31,7 +31,7 @@ Item {
         }
       }
       Button {
-        text: qsTr("Close")
+        text: i18n.tr("Close")
         color: theme.palette.normal.negative
         onClicked: {
           PopupUtils.close(dialogue)
@@ -39,7 +39,7 @@ Item {
         }
       }
       Button {
-        text: qsTr("Cancel")
+        text: i18n.tr("Cancel")
         onClicked: {
           PopupUtils.close(dialogue)
         }

--- a/ubports-seabass/qml/generic/EditorApi.qml
+++ b/ubports-seabass/qml/generic/EditorApi.qml
@@ -52,7 +52,7 @@ QtObject {
       QmlJs.readFile(filePath, function(err, text) {
         if (err) {
           console.error(err)
-          return errorOccured(qsTr('Unable to read file. Please ensure that you have read access to the') + ' ' + filePath)
+          return errorOccured(i18n.tr('Unable to read file. Please ensure that you have read access to the') + ' ' + filePath)
         }
 
         postMessage('loadFile', {
@@ -86,7 +86,7 @@ QtObject {
             isSaveInProgress = false
             if (err) {
                 console.error(err)
-                errorOccured(qsTr('Unable to write the file. Please ensure that you have write access to') + ' ' + filePath)
+                errorOccured(i18n.tr('Unable to write the file. Please ensure that you have write access to') + ' ' + filePath)
                 return callback(err)
             }
 


### PR DESCRIPTION
Without any changes, your .pot file (translation template) is empty except of one string=the apps name. So the app is not translatable.

Currently you are using the keyword `qsTr` for marking translatable strings. I know this is supposed to work somehow too, but I don't know how to fix that in cmakelist.txt.

A simple fix is to use `i18n.tr`as keyword. Most UT apps do use this anyway. So I exchanged all keywords to this and updated the pot file.

I also added a German translation.

*Note: This does not pick up the content of index.html for translation. That does still come up in English.*