### PR TITLE
add settings page with in app theme selection

### DIFF
--- a/ubports-seabass/po/seabass2.mikhael.pot
+++ b/ubports-seabass/po/seabass2.mikhael.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: seabass2.mikhael\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-12 21:25+0000\n"
+"POT-Creation-Date: 2020-09-15 19:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -60,16 +60,8 @@ msgstr ""
 msgid "Select theme:"
 msgstr ""
 
-#: ../qml/Settings.qml:54
+#: ../qml/Settings.qml:59
 msgid "System theme"
-msgstr ""
-
-#: ../qml/Settings.qml:61
-msgid "Ambiance theme"
-msgstr ""
-
-#: ../qml/Settings.qml:68
-msgid "Suru-dark theme"
 msgstr ""
 
 #: ../qml/components/Builder.qml:28

--- a/ubports-seabass/po/seabass2.mikhael.pot
+++ b/ubports-seabass/po/seabass2.mikhael.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: seabass2.mikhael\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-08 09:44+0000\n"
+"POT-Creation-Date: 2020-09-12 21:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../qml/About.qml:22 ../qml/components/Header.qml:70
+#: ../qml/About.qml:22 ../qml/components/Header.qml:76
 msgid "About"
 msgstr ""
 
@@ -35,17 +35,41 @@ msgstr ""
 msgid "Seabass2"
 msgstr ""
 
-#: ../qml/Main.qml:53
+#: ../qml/Main.qml:56
 msgid "Unable to read file. Please ensure that you have read access to the %1"
 msgstr ""
 
-#: ../qml/Main.qml:54
+#: ../qml/Main.qml:57
 msgid ""
 "Unable to write the file. Please ensure that you have write access to %1"
 msgstr ""
 
-#: ../qml/Main.qml:241
+#: ../qml/Main.qml:245
 msgid "Build (%1) failed. See build output for details"
+msgstr ""
+
+#: ../qml/Settings.qml:22 ../qml/components/Header.qml:71
+msgid "Settings"
+msgstr ""
+
+#: ../qml/Settings.qml:23
+msgid "for seabass2"
+msgstr ""
+
+#: ../qml/Settings.qml:50
+msgid "Select theme:"
+msgstr ""
+
+#: ../qml/Settings.qml:54
+msgid "System theme"
+msgstr ""
+
+#: ../qml/Settings.qml:61
+msgid "Ambiance theme"
+msgstr ""
+
+#: ../qml/Settings.qml:68
+msgid "Suru-dark theme"
 msgstr ""
 
 #: ../qml/components/Builder.qml:28
@@ -101,7 +125,7 @@ msgstr ""
 msgid "%1 will be deleted"
 msgstr ""
 
-#: ../qml/components/Header.qml:64
+#: ../qml/components/Header.qml:65
 msgid "Keyboard extension"
 msgstr ""
 

--- a/ubports-seabass/qml/Main.qml
+++ b/ubports-seabass/qml/Main.qml
@@ -25,14 +25,17 @@ ApplicationWindow {
   readonly property string defaultTitle: i18n.tr("Welcome")
   readonly property string defaultSubTitle: i18n.tr("Seabass2")
   readonly property string version: "0.10.0"
+  signal themeChanged()
 
   Component.onCompleted: {
     i18n.domain = "seabass2.mikhael"
+    setCurrentTheme();
   }
 
   Settings {
     id: settings
     property bool isKeyboardExtensionVisible: true
+    property string selectedTheme: "System"
   }
 
   GenericComponents.EditorApi {
@@ -228,6 +231,7 @@ ApplicationWindow {
             }
           }
           onAboutPageRequested: pageStack.push(Qt.resolvedUrl("About.qml"), { version: root.version })
+          onSettingsPageRequested: pageStack.push(Qt.resolvedUrl("Settings.qml"))
           onSaveRequested: {
             api.getFileContent(function(fileContent) {
               api.saveFile(api.filePath, fileContent)
@@ -364,4 +368,27 @@ ApplicationWindow {
       }
     }
   }
+
+    /*
+      Sets the system theme according to the theme selected
+      under settings.
+    */
+    function setCurrentTheme() {
+        if (settings.selectedTheme == "System") {
+          theme.name = "";
+          QmlJs.isDarker(theme.palette.normal.background,
+            theme.palette.normal.backgroundText);
+        } else if (settings.selectedTheme == "Suru-dark") {
+          theme.name = "Ubuntu.Components.Themes.SuruDark";
+          api.isDarkTheme = true;
+        } else if (settings.selectedTheme == "Ambiance") {
+          theme.name = "Ubuntu.Components.Themes.Ambiance";
+          api.isDarkTheme = false;
+        } else {
+          theme.name = "";
+        }
+    }
+
+    onThemeChanged: setCurrentTheme()
+
 }

--- a/ubports-seabass/qml/Main.qml
+++ b/ubports-seabass/qml/Main.qml
@@ -376,17 +376,19 @@ ApplicationWindow {
     function setCurrentTheme() {
         if (settings.selectedTheme == "System") {
           theme.name = "";
-          QmlJs.isDarker(theme.palette.normal.background,
-            theme.palette.normal.backgroundText);
-        } else if (settings.selectedTheme == "Suru-dark") {
+          Suru.theme = undefined;
+        } else if (settings.selectedTheme == "Suru-Dark") {
           theme.name = "Ubuntu.Components.Themes.SuruDark";
-          api.isDarkTheme = true;
+          Suru.theme = Suru.Dark;
         } else if (settings.selectedTheme == "Ambiance") {
-          theme.name = "Ubuntu.Components.Themes.Ambiance";
-          api.isDarkTheme = false;
+          theme.name = "Ubuntu.Components.Themes.Ambiance"
+          Suru.theme = Suru.Light;
         } else {
           theme.name = "";
+          Suru.theme = undefined;
         }
+        api.isDarkTheme = QmlJs.isDarker(theme.palette.normal.background,
+          theme.palette.normal.backgroundText);
     }
 
     onThemeChanged: setCurrentTheme()

--- a/ubports-seabass/qml/Settings.qml
+++ b/ubports-seabass/qml/Settings.qml
@@ -1,0 +1,77 @@
+import QtQuick 2.4
+import QtQuick.Controls 2.2
+import QtQuick.Controls.Suru 2.2
+import QtQuick.Layouts 1.3
+
+import './components/common' as CustomComponents
+
+Item {
+    id: settingsPage
+
+    // readonly property string sourceUrl: 'github.com/milikhin/seabass2'
+
+    ColumnLayout {
+        anchors.fill: parent
+
+        CustomComponents.ToolBar {
+            id: header
+            Layout.fillWidth: true
+
+            hasLeadingButton: true
+            onLeadingAction: pageStack.pop()
+            title: i18n.tr("Settings")
+            subtitle: i18n.tr("for seabass2")
+        }
+
+        Flickable {
+            id: settingsFlickable
+            clip: true
+            flickableDirection: Flickable.AutoFlickIfNeeded
+
+            anchors {
+                topMargin: header.height
+                fill: parent
+            }
+
+            contentHeight: settingsColumn.childrenRect.height
+
+            Column {
+                id: settingsColumn
+
+                anchors {
+                    top: parent.top
+                    left: parent.left
+                    right: parent.right
+                    margins: units.gu(2)
+                }
+                spacing: units.gu(1)
+
+                Label {
+                    text: i18n.tr("Select theme:")
+                }
+
+                Button {
+                    text: i18n.tr("System theme")
+                    onClicked: {
+                        settings.selectedTheme = "System";
+                        root.setCurrentTheme();
+                    }
+                }
+                Button {
+                    text: i18n.tr("Ambiance theme")
+                    onClicked: {
+                        settings.selectedTheme = "Ambiance";
+                        root.setCurrentTheme();
+                    }
+                }
+                Button {
+                    text: i18n.tr("Suru-dark theme")
+                    onClicked: {
+                        settings.selectedTheme = "Suru-dark";
+                        root.setCurrentTheme();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ubports-seabass/qml/Settings.qml
+++ b/ubports-seabass/qml/Settings.qml
@@ -48,27 +48,47 @@ Item {
 
                 Label {
                     text: i18n.tr("Select theme:")
+                    font.bold: true
                 }
 
-                Button {
-                    text: i18n.tr("System theme")
-                    onClicked: {
-                        settings.selectedTheme = "System";
-                        root.setCurrentTheme();
+                Row {
+                    id: themeRow
+                    spacing: units.gu(1.5)
+                    Label {
+                        id: systemLabel
+                        text: i18n.tr("System theme")
+                        color: settings.selectedTheme === "System" ? theme.palette.normal.selection : theme.palette.normal.backgroundSecondaryText
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                settings.selectedTheme = "System";
+                                root.setCurrentTheme();
+                            }
+                        }
                     }
-                }
-                Button {
-                    text: i18n.tr("Ambiance theme")
-                    onClicked: {
-                        settings.selectedTheme = "Ambiance";
-                        root.setCurrentTheme();
+                    Label {
+                        id: ambianceLabel
+                        text: "Ambiance"
+                        color: settings.selectedTheme === "Ambiance" ? theme.palette.normal.selection : theme.palette.normal.backgroundSecondaryText
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                settings.selectedTheme = "Ambiance";
+                                root.setCurrentTheme();
+                            }
+                        }
                     }
-                }
-                Button {
-                    text: i18n.tr("Suru-dark theme")
-                    onClicked: {
-                        settings.selectedTheme = "Suru-dark";
-                        root.setCurrentTheme();
+                    Label {
+                        id: surudarkLabel
+                        text: "Suru-Dark"
+                        color: settings.selectedTheme === "Suru-Dark" ? theme.palette.normal.selection : theme.palette.normal.backgroundSecondaryText
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                settings.selectedTheme = "Suru-Dark";
+                                root.setCurrentTheme();
+                            }
+                        }
                     }
                 }
             }

--- a/ubports-seabass/qml/components/Header.qml
+++ b/ubports-seabass/qml/components/Header.qml
@@ -17,6 +17,7 @@ CustomComponents.ToolBar {
 
   signal navBarToggled()
   signal aboutPageRequested()
+  signal settingsPageRequested()
   signal saveRequested()
   signal buildRequested()
   signal keyboardExtensionToggled()
@@ -64,6 +65,11 @@ CustomComponents.ToolBar {
         text: i18n.tr("Keyboard extension")
         enabled: searchEnabled
         onTriggered: keyboardExtensionToggled()
+      }
+      CustomComponents.MenuItem {
+        icon: "settings"
+        text: i18n.tr("Settings")
+        onTriggered: settingsPageRequested()
       }
       CustomComponents.MenuItem {
         icon: "info"


### PR DESCRIPTION
This MR (so far) does add a settings page and the basic structure to change the theme within the app.
The settings page in a simple proof-of-concept layout will look like this:

![screenshot20200912_233707185](https://user-images.githubusercontent.com/37637312/93005444-3646ff00-f551-11ea-9cd7-94dc2d36096e.png)

But changing the theme does not change it for the header and settings page itself. I guess this is due to the suru components stuff. I have not used that. Main pages It does look like this when changing the theme:

![screenshot20200912_233716423](https://user-images.githubusercontent.com/37637312/93005473-81611200-f551-11ea-9766-3c5332499d87.png)
![screenshot20200912_233725079](https://user-images.githubusercontent.com/37637312/93005474-81f9a880-f551-11ea-86f3-d79dd6a88cd1.png)

So far this is more for you to learn how a pure qml in-app thema change can be implemented. Sadly I am short of time currently. If I find more time, I can try to make a nicer layout for the settings and get it working properly. But maybe it is enough for you to do this yourself.

Or maybe @cibersheep can help with the Suru stuff?