### PR TITLE
add option to open terminal app at files location

### DIFF
--- a/ubports-seabass/qml/Main.qml
+++ b/ubports-seabass/qml/Main.qml
@@ -260,6 +260,11 @@ ApplicationWindow {
             editor.forceActiveFocus()
             api.postMessage('toggleSearch')
           }
+          onOpenTerminalApp: {
+              if (api.filePath) {
+                  Qt.openUrlExternally("terminal://?path=" + api.filePath.split('/').slice(0, -1).join('/'))
+              }
+          }
         }
 
         CustomComponents.TabBar {

--- a/ubports-seabass/qml/components/Header.qml
+++ b/ubports-seabass/qml/components/Header.qml
@@ -22,6 +22,7 @@ CustomComponents.ToolBar {
   signal buildRequested()
   signal keyboardExtensionToggled()
   signal search()
+  signal openTerminalApp()
 
   hasLeadingButton: navBarCanBeOpened
   leadingIcon: "document-open"
@@ -41,6 +42,10 @@ CustomComponents.ToolBar {
     visible: buildable
     enabled: buildEnabled
     onClicked: buildRequested()
+  }
+  CustomComponents.ToolButton {
+    icon: "terminal-app-symbolic"
+    onClicked: openTerminalApp()
   }
   CustomComponents.ToolButton {
     icon: "search"


### PR DESCRIPTION
I proposed an [MR](https://gitlab.com/ubports/apps/terminal-app/-/merge_requests/88) to terminal app implementing an URLdispatcher. Once merged and after a new release of terminal app seabass can facilitate this too.

With this PR a header icon is added that does open Terminal app at the current active file's location.

I do mark this as WIP because of terminal app's prerequisites. Of course feel free to merge anyway and wait with your release until the next release of terminal app.